### PR TITLE
Expose environment telemetry in HUD and stats

### DIFF
--- a/humlet_simulation/simulation.py
+++ b/humlet_simulation/simulation.py
@@ -481,6 +481,7 @@ class Simulation:
 
         # HUD (top bar, over world area)
         pop = len(self.humlets)
+        food_count = sum(1 for obj in self.env.objects if isinstance(obj, Food))
         info = (
             f"Tick: {self.tick}   "
             f"Pop: {pop}   "
@@ -490,6 +491,19 @@ class Simulation:
         )
         text_surface = self.font_medium.render(info, True, (255, 255, 255))
         self.screen.blit(text_surface, (10, 10))
+
+        # Secondary HUD line with environment / ecology context
+        day_frac = (self.env.time % max(1, self.env.day_length)) / max(1, self.env.day_length)
+        season_frac = (self.env.time % max(1, self.env.season_length)) / max(1, self.env.season_length)
+        info2 = (
+            f"Day: {day_frac * 100:5.1f}%   "
+            f"Season: {season_frac * 100:5.1f}%   "
+            f"Light: {self.env.light_level:.2f}   "
+            f"Wild food: {food_count}/{self.env.food_capacity}   "
+            f"Food pool: {self.env.food_energy_pool:.0f}"
+        )
+        text_surface2 = self.font_small.render(info2, True, (220, 220, 220))
+        self.screen.blit(text_surface2, (10, 32))
 
         # inside your draw loop, after screen fill and before display.flip()
         if humlet is self.selected_humlet:
@@ -867,6 +881,17 @@ class Simulation:
             y2 = draw_line(f"Food / cap : {s.avg_food_per_capita:.2f}", x2, y2)
             y2 = draw_line(f"Wood / cap : {s.avg_wood_per_capita:.2f}", x2, y2)
             y2 = draw_line(f"Stone / cap: {s.avg_stone_per_capita:.2f}", x2, y2)
+
+            y2 += 4
+            y2 = draw_header("== Environment ==", x2, y2, (200, 230, 255))
+            y2 = draw_line(f"Day phase  : {s.day_progress * 100:5.1f}%", x2, y2)
+            y2 = draw_line(f"Season     : {s.season_progress * 100:5.1f}%", x2, y2)
+            y2 = draw_line(f"Light lvl  : {s.light_level:.2f}", x2, y2)
+            y2 = draw_line(
+                f"Wild food  : {s.wild_food_count}/{s.food_capacity}", x2, y2
+            )
+            y2 = draw_line(f"Food pool  : {s.food_energy_pool:.0f}", x2, y2)
+            y2 = draw_line(f"Product/tk : {s.productivity_per_tick:.1f}", x2, y2)
 
 
 

--- a/humlet_simulation/stats.py
+++ b/humlet_simulation/stats.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import List
 
 from .humlet import Humlet
-from .environment import Environment
+from .environment import Environment, Food
 import math
 
 
@@ -64,6 +64,15 @@ class StatsSnapshot:
     avg_wood_per_capita: float
     avg_stone_per_capita: float
 
+    # Environment / ecology outputs
+    wild_food_count: int
+    food_capacity: int
+    food_energy_pool: float
+    productivity_per_tick: float
+    light_level: float
+    day_progress: float
+    season_progress: float
+
 
 # ----------------------------------------------------------------------
 # Global evolution stats over time
@@ -90,12 +99,28 @@ class EvolutionStats:
 
         # Default village stats if env not passed
         v_food = v_wood = v_stone = 0.0
+        food_capacity = 0
+        food_energy_pool = 0.0
+        productivity_per_tick = 0.0
+        light_level = 0.0
+        day_progress = 0.0
+        season_progress = 0.0
+        wild_food_count = 0
 
         if env is not None and hasattr(env, "village"):
             totals = env.village.totals()
             v_food = totals.get("food", 0.0)
             v_wood = totals.get("wood", 0.0)
             v_stone = totals.get("stone", 0.0)
+            food_capacity = getattr(env, "food_capacity", 0)
+            food_energy_pool = getattr(env, "food_energy_pool", 0.0)
+            productivity_per_tick = getattr(env, "_productivity_per_tick", 0.0)
+            light_level = getattr(env, "light_level", 0.0)
+            day_length = getattr(env, "day_length", 1) or 1
+            season_length = getattr(env, "season_length", 1) or 1
+            day_progress = (getattr(env, "time", 0) % day_length) / day_length
+            season_progress = (getattr(env, "time", 0) % season_length) / season_length
+            wild_food_count = sum(1 for o in env.objects if isinstance(o, Food))
 
         if n == 0:
             snapshot = StatsSnapshot(
@@ -138,6 +163,14 @@ class EvolutionStats:
                 avg_food_per_capita=0.0,
                 avg_wood_per_capita=0.0,
                 avg_stone_per_capita=0.0,
+                # ecology
+                wild_food_count=wild_food_count,
+                food_capacity=food_capacity,
+                food_energy_pool=food_energy_pool,
+                productivity_per_tick=productivity_per_tick,
+                light_level=light_level,
+                day_progress=day_progress,
+                season_progress=season_progress,
             )
         else:
             def avg(fn): return sum(fn(h) for h in alive) / n
@@ -245,6 +278,14 @@ class EvolutionStats:
                 avg_food_per_capita=avg_food_per_capita,
                 avg_wood_per_capita=avg_wood_per_capita,
                 avg_stone_per_capita=avg_stone_per_capita,
+                # ecology
+                wild_food_count=wild_food_count,
+                food_capacity=food_capacity,
+                food_energy_pool=food_energy_pool,
+                productivity_per_tick=productivity_per_tick,
+                light_level=light_level,
+                day_progress=day_progress,
+                season_progress=season_progress,
             )
 
         self.latest = snapshot


### PR DESCRIPTION
## Summary
- add an extra HUD line showing day/season progress, light level, and food availability
- track environment metrics in the stats snapshot and render them in the right-hand inspector panel

## Testing
- python -m py_compile main.py $(find humlet_simulation -name '*.py')

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d78a4b6e48322b697013bf3d0b109)