### PR TITLE
Add reproducible seeding and trajectory logging

### DIFF
--- a/humlet_simulation/stats.py
+++ b/humlet_simulation/stats.py
@@ -1,7 +1,7 @@
 # humlet_simulation/stats.py
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import List
 
 from .humlet import Humlet
@@ -92,6 +92,14 @@ class EvolutionStats:
     max_history_len: int = 500
 
     latest: StatsSnapshot | None = None
+
+    def latest_as_dict(self) -> dict | None:
+        if self.latest is None:
+            return None
+        return asdict(self.latest)
+
+    def history_as_dicts(self) -> list[dict]:
+        return [asdict(s) for s in self.history]
 
     def update(self, tick: int, humlets: List[Humlet], env: Environment | None = None) -> None:
         alive = [h for h in humlets if h.alive]


### PR DESCRIPTION
## Summary
- add run-level seed management and record agent seeds for reproducibility
- give each Humlet deterministic RNGs and pass seeds through reproduction
- add optional trajectory logging with serializable evolution snapshots

## Testing
- python -m compileall humlet_simulation


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d7c9ee68083228e8fa22790487c77)