### PR TITLE
Simplify smell detection to ignore occlusions

### DIFF
--- a/humlet_simulation/sensors/smell.py
+++ b/humlet_simulation/sensors/smell.py
@@ -37,11 +37,6 @@ class Smell:
             if dist <= 1e-6 or dist > self.range:
                 continue
 
-            # Block scent if a solid object occludes the shortest path
-            if hasattr(self.owner, "_has_line_of_sight"):
-                if not self.owner._has_line_of_sight(environment, obj.x, obj.y, target=obj, target_radius=getattr(obj, "radius", 0.0)):
-                    continue
-
             # Stronger weight for closer food
             strength = (self.range - dist) / self.range
             fx += dx * strength * self.sensitivity


### PR DESCRIPTION
## Summary
- allow smell sensing to accumulate scent without occlusion checks so wraparound detection works reliably

## Testing
- pytest tests/test_environment_and_humlet.py::test_smell_uses_toroidal_wraparound *(fails to collect because numpy is unavailable in the environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e4d062af083228364cc9ad4889843)