### PR TITLE
Improve simulation performance with spatial indices

### DIFF
--- a/humlet_simulation/spatial_hash.py
+++ b/humlet_simulation/spatial_hash.py
@@ -27,6 +27,17 @@ class SpatialHash:
         """Insert an object at position (x, y)."""
         cell = self._get_cell(x, y)
         self.grid[cell].append(obj)
+
+    def remove(self, obj, x: float, y: float) -> None:
+        """Remove an object from the spatial hash if present."""
+        cell = self._get_cell(x, y)
+        if cell not in self.grid:
+            return
+        bucket = self.grid[cell]
+        if obj in bucket:
+            bucket.remove(obj)
+            if not bucket:
+                del self.grid[cell]
     
     def query_radius(self, x: float, y: float, radius: float) -> List:
         """


### PR DESCRIPTION
## Summary
- add a spatial hash for world objects and route resource interactions through indexed queries
- reuse the humlet spatial index across ticks, rebuilding once per step and lowering fast-mode update bursts
- batch region trait heatmap calculations to reduce per-frame overhead

## Testing
- python -m compileall humlet_simulation

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e513a877c832296ce3f29bfa70607)