### PR TITLE
Add rest output labeling and stats tracking

### DIFF
--- a/humlet_simulation/simulation.py
+++ b/humlet_simulation/simulation.py
@@ -1194,7 +1194,7 @@ class Simulation:
         else:
             input_labels = input_labels[:n_in]
 
-        output_labels = ["Move X", "Move Y", "Eat", "Reproduce"]
+        output_labels = ["Move X", "Move Y", "Eat", "Reproduce", "Rest"]
         if len(output_labels) < n_out:
             output_labels += [f"Out {k}" for k in range(len(output_labels), n_out)]
         else:
@@ -1359,7 +1359,7 @@ class Simulation:
 
         y += line_h // 2
         draw("Outputs", (255, 220, 160))
-        labels = ["Move X", "Move Y", "Eat", "Reproduce"]
+        labels = ["Move X", "Move Y", "Eat", "Reproduce", "Rest"]
         for k, val in enumerate(outputs):
             if y > rect.bottom - 3 * line_h:
                 break
@@ -1536,7 +1536,7 @@ class Simulation:
             draw_inactive_marker(x_hid, y, hidden[j])
 
         # Output nodes + small labels
-        output_labels = ["Mx", "My", "Eat", "Repr"]
+        output_labels = ["Mx", "My", "Eat", "Repr", "Rest"]
         for k, y in enumerate(y_out):
             col = node_color(outputs[k])
             pygame.draw.circle(self.screen, col, (x_out, y), radius)

--- a/humlet_simulation/stats.py
+++ b/humlet_simulation/stats.py
@@ -35,6 +35,9 @@ class StatsSnapshot:
     avg_digestion_flow: float
     avg_absorption_efficiency: float
 
+    # Neural rest behaviour
+    avg_rest_intensity: float
+
     # New: physical body traits / growth
     avg_mass: float
     avg_height: float
@@ -151,6 +154,7 @@ class EvolutionStats:
                 avg_stomach_fill=0.0,
                 avg_digestion_flow=0.0,
                 avg_absorption_efficiency=0.0,
+                avg_rest_intensity=0.0,
                 # physical
                 avg_mass=0.0,
                 avg_height=0.0,
@@ -227,6 +231,7 @@ class EvolutionStats:
             )
             avg_digestion_flow = avg(lambda h: getattr(h, "digestion_flow", 0.0))
             avg_absorption_efficiency = avg(lambda h: getattr(h, "absorption_efficiency", 0.0))
+            avg_rest_intensity = avg(lambda h: getattr(h, "rest_intensity", 0.0))
 
             # Physical body
             avg_mass = avg(lambda h: getattr(h, "mass", 0.0))
@@ -279,6 +284,7 @@ class EvolutionStats:
                 avg_stomach_fill=avg_stomach_fill,
                 avg_digestion_flow=avg_digestion_flow,
                 avg_absorption_efficiency=avg_absorption_efficiency,
+                avg_rest_intensity=avg_rest_intensity,
                 # physical
                 avg_mass=avg_mass,
                 avg_height=avg_height,


### PR DESCRIPTION
## Summary
- label the brain rest output alongside existing action outputs in both brain diagrams and textual inspector info
- track average rest intensity in the population stats snapshot for reporting

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eb5f790388322a104405bfe50faa5)